### PR TITLE
Add mobile view for past-activities-section and past-header.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -270,10 +270,22 @@ form {
    width: 90%;
    margin-bottom: 1%;
  }
- 
+
   .start-activity-button {
     font-size: 20px;
     height: 13%;
     width: 60%;
     margin: 3% auto;
   }
+
+  .past-activities-section {
+   border: none;
+   border-top: 3px solid #46424D;
+   margin-top: 75px;
+   width: 100%;
+ }
+ 
+ #past-header {
+   margin-top: 30px;
+ }
+}


### PR DESCRIPTION
This PR addresses the mobile view for the past-activities section and the past-header. Again our mobile view is set to 600px. Changes can be viewed in out styles.css file.